### PR TITLE
Fix typo in README start command

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@ npm run resetconfig
 
 ## Documentation
 
-The API's calls are mapped to various API methods from [Riot Game's documentation](https://developer.riotgames.com/api/methods). All URLs can accept `apiKey` and `region` as **query string parameters**, if you want to do calls for a different **region** or with a **different key** than the specified defaults.
+The API's calls are mapped to various API methods from [Riot Game's documentation](https://developer.riotgames.com/docs/lol). All URLs can accept `apiKey` and `region` as **query string parameters**, if you want to do calls for a different **region** or with a **different key** than the specified defaults.
 
 ### Routes
 

--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ lol-riot-api is installable via:
 ## Getting started
 To start the API server run the following command:
 ```js
-node run start
+npm run start
 ```
 You will have to do a **one time** configuration to be able to use the API. At the prompt you will be asked for the default API `key` to be used for the calls, the `port` on which the API will run, the default `region` to be used for the API calls and the caching strategy.
 


### PR DESCRIPTION
Fixed a typo.

```js
node run start // wrong
```

```js
npm run start // correct
```

Also this url [https://developer.riotgames.com/api/methods](https://developer.riotgames.com/api/methods) is not working anymore. So i changed it with the updated documentation link.